### PR TITLE
Fix error pathing issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ function inline(it, keyword, schema) {
             ${valid} = true;
             var ${err} = {
                 keyword: "${keyword}",
-                dataPath: "${it.dataPathArr[it.dataLevel] || ''}",
+                dataPath: (dataPath || '') + ${it.errorPath},
                 schemaPath: "${it.schemaPath}",
                 data: ${data}
             };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ajv-moment",
-  "version": "2.0.1",
+  "name": "ajv-moment-bf",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ajv-moment",
+  "name": "ajv-moment-bf",
   "version": "2.0.2",
   "description": "robust date validation for ajv",
   "main": "./dist/index.js",
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cludden/ajv-moment.git"
+    "url": "https://github.com/bfeister/ajv-moment.git"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ajv-moment",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "robust date validation for ajv",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
From within an `inline` function of my own, logging `it.dataPathArr[it.dataLevel]` yields as follows (which fails to account for full schema nesting / path:

```
"'localDateTime'"
```

Whereas logging `it.errorPath` yields (which appears to yield the full path):

```
'/shifts/' + i3 + '/start/localDateTime'
```

More context is provided in the issue I opened [here](https://github.com/cludden/ajv-moment/issues/6). I'm not certain how to compile this to dist and test locally, but I think this is the correct fix. Related to https://github.com/cludden/ajv-moment/issues/6
