### PR TITLE
Fix typings export and path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "type": "git",
     "url": "https://github.com/cludden/ajv-moment.git"
   },
-  "types": "index.d.ts",
+  "types": "typings/index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "ajv": "^4.1.7",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,3 @@
 declare module "ajv-moment" {
-  function plugin(options: any);
-  export = plugin;
+  export function plugin(options: any);
 }


### PR DESCRIPTION
The TypeScript types file is located at `typings/index.d.ts` but the package.json pointed to (`./`)`index.d.ts`. Also, since the JS file is an ECMAScript module ([uses the `export` keyword](https://github.com/cludden/ajv-moment/blob/98dca1d3862f656cdee7d3d0a9347d8f42d40016/lib/index.js#L182)), the type definitions should match this as well.