### PR TITLE
Explicitly define return type in type definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,3 @@
 declare module "ajv-moment" {
-  export function plugin(options: any);
+  export function plugin(options: any): any;
 }


### PR DESCRIPTION
A follow-up on #21, I forgot to define a return type. This fixes typescript error TS7010 when attempting to import the `ajv-moment` package.

![Screen Shot 2020-09-25 at 12 03 28](https://user-images.githubusercontent.com/5085260/94254542-35d23f00-ff27-11ea-86b8-fd2665cd3624.png)
